### PR TITLE
Fix Vehicle Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ download links are also provided below.
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:1.0.0"
+compile "com.smartcar.sdk:java-sdk:1.0.1"
 ```
 
 ### Maven
@@ -19,14 +19,14 @@ compile "com.smartcar.sdk:java-sdk:1.0.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-1.0.0.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.0.jar)
-* [java-sdk-1.0.0-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.0-sources.jar)
-* [java-sdk-1.0.0-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.0-docs.jar)
+* [java-sdk-1.0.1.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.1.jar)
+* [java-sdk-1.0.1-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.1-sources.jar)
+* [java-sdk-1.0.1-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F1.0.0%2Fjava-sdk-1.0.1-docs.jar)
 
 
 ## Usage
@@ -126,5 +126,5 @@ start making requests to vehicles.
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-1.0.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-1.0.1-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ test {
         showExceptions = true
         exceptionFormat = 'full'
         showStackTraces = true
+        showStandardStreams = true
     }
 
     afterTest { desc, result ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=1.0.0
+libVersion=1.0.1
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/main/java/com/smartcar/sdk/Vehicle.java
+++ b/src/main/java/com/smartcar/sdk/Vehicle.java
@@ -60,9 +60,13 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   private <T extends ApiData> SmartcarResponse<T> call(String path, String method, RequestBody body, Class<T> type) throws SmartcarException {
-    HttpUrl url = HttpUrl.parse(Vehicle.URL_API + "/vehicles/" + this.vehicleId).newBuilder()
+    HttpUrl url = HttpUrl.parse(Vehicle.URL_API).newBuilder()
+        // addPathSegments will take care of adding leading `/`
+        .addPathSegments("vehicles")
+        .addPathSegments(this.vehicleId)
         .addPathSegments(path)
         .build();
+
     Request request = new Request.Builder()
         .url(url)
         .header("Authorization", "Bearer " + this.accessToken)
@@ -107,7 +111,7 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   public String vin() throws SmartcarException {
-    return this.call("/vin", "GET", null, VehicleVin.class).getData().getVin();
+    return this.call("vin", "GET", null, VehicleVin.class).getData().getVin();
   }
 
   /**
@@ -118,7 +122,7 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   public String[] permissions() throws SmartcarException {
-    return this.call("/permissions", "GET", null, ApplicationPermissions.class).getData().getPermissions();
+    return this.call("permissions", "GET", null, ApplicationPermissions.class).getData().getPermissions();
   }
 
   /**
@@ -127,7 +131,7 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   public void disconnect() throws SmartcarException {
-    this.call("/disconnect", "DELETE", null);
+    this.call("disconnect", "DELETE", null);
   }
 
   /**
@@ -138,7 +142,7 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   public SmartcarResponse odometer() throws SmartcarException {
-    return this.call("/odometer", "GET", null, VehicleOdometer.class);
+    return this.call("odometer", "GET", null, VehicleOdometer.class);
   }
 
   /**
@@ -149,7 +153,7 @@ public class Vehicle extends ApiClient {
    * @throws SmartcarException if the request is unsuccessful
    */
   public SmartcarResponse location() throws SmartcarException {
-    return this.call("/location", "GET", null, VehicleLocation.class);
+    return this.call("location", "GET", null, VehicleLocation.class);
   }
 
   /**
@@ -162,7 +166,7 @@ public class Vehicle extends ApiClient {
       .add("action", "UNLOCK")
       .build();
 
-    this.call("/security", "POST", body);
+    this.call("security", "POST", body);
   }
 
   /**
@@ -175,7 +179,7 @@ public class Vehicle extends ApiClient {
       .add("action", "LOCK")
       .build();
 
-    this.call("/security", "POST", body);
+    this.call("security", "POST", body);
   }
 
   /**

--- a/src/test/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/test/java/com/smartcar/sdk/VehicleTest.java
@@ -59,7 +59,7 @@ public class VehicleTest {
     SmartcarResponse res = new SmartcarResponse<VehicleVin>(expected);
 
     PowerMockito.doReturn(res)
-      .when(this.subject, "call", "/vin", "GET", null, VehicleVin.class);
+      .when(this.subject, "call", "vin", "GET", null, VehicleVin.class);
 
     String vin = this.subject.vin();
 
@@ -74,7 +74,7 @@ public class VehicleTest {
     SmartcarResponse res = new SmartcarResponse<ApplicationPermissions>(expected);
 
     PowerMockito.doReturn(res)
-      .when(this.subject, "call", "/permissions", "GET", null, ApplicationPermissions.class);
+      .when(this.subject, "call", "permissions", "GET", null, ApplicationPermissions.class);
 
     String[] permissions = this.subject.permissions();
 
@@ -88,7 +88,7 @@ public class VehicleTest {
     SmartcarResponse res = new SmartcarResponse(data);
 
     PowerMockito.doReturn(res.toString())
-      .when(this.subject, "call", "/disconnect", "DELETE", null);
+      .when(this.subject, "call", "disconnect", "DELETE", null);
 
     this.subject.disconnect();
   }
@@ -102,7 +102,7 @@ public class VehicleTest {
     SmartcarResponse res = new SmartcarResponse<VehicleOdometer>(expected, unitSystem, age);
 
     PowerMockito.doReturn(res)
-      .when(this.subject, "call", "/odometer", "GET", null, VehicleOdometer.class);
+      .when(this.subject, "call", "odometer", "GET", null, VehicleOdometer.class);
 
     SmartcarResponse odometer = this.subject.odometer();
 
@@ -119,7 +119,7 @@ public class VehicleTest {
     SmartcarResponse res = new SmartcarResponse<VehicleLocation>(expected, unitSystem, age);
 
     PowerMockito.doReturn(res)
-      .when(this.subject, "call", "/location", "GET", null, VehicleLocation.class);
+      .when(this.subject, "call", "location", "GET", null, VehicleLocation.class);
 
     SmartcarResponse location = this.subject.location();
 
@@ -136,7 +136,7 @@ public class VehicleTest {
       .build();
 
     PowerMockito.doReturn(res.toString())
-      .when(this.subject, "call", eq("/security"), eq("POST"), refEq(body));
+      .when(this.subject, "call", eq("security"), eq("POST"), refEq(body));
 
     this.subject.unlock();
   }
@@ -151,7 +151,7 @@ public class VehicleTest {
       .build();
 
     PowerMockito.doReturn(res.toString())
-      .when(this.subject, "call", eq("/security"), eq("POST"), refEq(body));
+      .when(this.subject, "call", eq("security"), eq("POST"), refEq(body));
 
     this.subject.lock();
   }


### PR DESCRIPTION
## Description

The `addPathSegments` function in `HttpUrl.Builder` class appends a `/` to the given path. In our usage of the builder, we passed a string with a leading slash (e.g. `"/vin"`) to `addPathSegments`, which caused our built urls to resemble: `https://api.smartcar.com/v1.0/4b709b6c-c50a-46a7-9239-0006d39f708f//vin`.