### PR TITLE
update user-agent header to include platform info

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=1.0.2
+libVersion=1.0.3
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/main/java/com/smartcar/sdk/ApiClient.java
+++ b/src/main/java/com/smartcar/sdk/ApiClient.java
@@ -22,8 +22,15 @@ import org.joda.time.DateTime;
 abstract class ApiClient {
   private static final String SDK_VERSION = ApiClient.class.getPackage().getImplementationVersion();
   private static final String API_VERSION = "v1.0";
-  protected static final String USER_AGENT = "smartcar-java-sdk: " + ApiClient.SDK_VERSION;
   protected static final String URL_API = "https://api.smartcar.com/" + ApiClient.API_VERSION;
+  protected static final String USER_AGENT = String.format(
+      "Smartcar/%s (%s; %s) Java v%s %s",
+      ApiClient.SDK_VERSION,
+      System.getProperty("os.name"),
+      System.getProperty("os.arch"),
+      System.getProperty("java.version"),
+      System.getProperty("java.vm.name")
+  );
 
   private static OkHttpClient client = new OkHttpClient();
   static GsonBuilder gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);

--- a/src/test/java/com/smartcar/sdk/ApiClientTest.java
+++ b/src/test/java/com/smartcar/sdk/ApiClientTest.java
@@ -1,0 +1,17 @@
+package com.smartcar.sdk;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test Suite: ApiClient
+ */
+public class ApiClientTest {
+
+  @Test
+  public void testUserAgent() {
+    // version has to be null because the package isn't built yet
+    String regex = "^Smartcar/null \\((\\w+); (\\w+)\\) Java v(\\d+\\.\\d+\\.\\d_\\d+) .*";
+    Assert.assertTrue(ApiClient.USER_AGENT.matches(regex));
+  }
+}


### PR DESCRIPTION
make the Java user-agent consistent with smartcar/node-sdk#56

example header: 
```
 Smartcar/4.0.1 (Linux; amd64) Java v1.8.0_171 Java HotSpot(TM) 64-Bit Server VM
```
Note this is slightly different from Python and Node because of the extra Java server info