### PR TITLE
Fix: smartcar factory bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ download links are also provided below.
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:2.1.2"
+compile "com.smartcar.sdk:java-sdk:2.1.3"
 ```
 
 ### Maven
@@ -19,14 +19,14 @@ compile "com.smartcar.sdk:java-sdk:2.1.2"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>2.1.2</version>
+  <version>2.1.3</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-2.1.2.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.2%2Fjava-sdk-2.1.2.jar)
-* [java-sdk-2.1.2-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.2%2Fjava-sdk-2.1.2-sources.jar)
-* [java-sdk-2.1.2-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.2%2Fjava-sdk-2.1.2-docs.jar)
+* [java-sdk-2.1.3.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.3%2Fjava-sdk-2.1.3.jar)
+* [java-sdk-2.1.3-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.3%2Fjava-sdk-2.1.3-sources.jar)
+* [java-sdk-2.1.3-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.1.3%2Fjava-sdk-2.1.3-docs.jar)
 
 
 ## Usage
@@ -133,5 +133,5 @@ start making requests to vehicles.
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-2.1.2-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-2.1.3-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=2.1.2
+libVersion=2.1.3
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/main/java/com/smartcar/sdk/SmartcarException.java
+++ b/src/main/java/com/smartcar/sdk/SmartcarException.java
@@ -76,14 +76,25 @@ public class SmartcarException extends java.lang.Exception {
   public static SmartcarException Factory(final Response response) throws IOException {
     JsonObject body = gson.fromJson(response.body().string(), JsonObject.class);
 
-    String code = null;
-    JsonElement codeElement = body.get("code");
-    if (codeElement != null) {
-      code = codeElement.getAsString();
-    }
-    String message = body.get("message").getAsString();
-    String error = body.get("error").getAsString();
     int statusCode = response.code();
+
+    String code = "";
+    if (body.has("code")) {
+      code = body.get("code").getAsString();
+    }
+
+    String message = "";
+    if (body.has("message")) {
+      message = body.get("message").getAsString();
+    } else if (body.has("error_description")) {
+      message = body.get("error_description").getAsString();
+    }
+
+    String error = "";
+    if (body.has("error")) {
+      error = body.get("error").getAsString();
+    }
+
     return new SmartcarException(statusCode, error, message, code);
   }
 }

--- a/src/test/java/com/smartcar/sdk/SmartcarExceptionTest.java
+++ b/src/test/java/com/smartcar/sdk/SmartcarExceptionTest.java
@@ -74,4 +74,46 @@ public class SmartcarExceptionTest extends PowerMockTestCase {
     Assert.assertEquals(ex.getError(), expectedError);
     Assert.assertEquals(ex.getStatusCode(), expectedStatusCode);
   }
+
+  /**
+   * Test SmartcarException.Factory with error_description
+   */
+  @Test
+  public void testSmartcarExceptionFactoryWithErrorDescription() throws Exception {
+    String expectedMessage = "expected message";
+    String response = Json.createObjectBuilder()
+              .add("error_description", expectedMessage)
+              .build()
+              .toString();
+    Response mockResponse = mock(Response.class);
+    ResponseBody mockResponseBody = mock(ResponseBody.class);
+
+    when(mockResponse.body()).thenReturn(mockResponseBody);
+    when(mockResponseBody.string()).thenReturn(response);
+
+    SmartcarException ex = SmartcarException.Factory(mockResponse);
+
+    Assert.assertEquals(ex.getMessage(), expectedMessage);
+  }
+
+  /**
+   * Test SmartcarException.Factory with message
+   */
+  @Test
+  public void testSmartcarExceptionFactoryWithMessage() throws Exception {
+    String expectedMessage = "expected message";
+    String response = Json.createObjectBuilder()
+              .add("message", expectedMessage)
+              .build()
+              .toString();
+    Response mockResponse = mock(Response.class);
+    ResponseBody mockResponseBody = mock(ResponseBody.class);
+
+    when(mockResponse.body()).thenReturn(mockResponseBody);
+    when(mockResponseBody.string()).thenReturn(response);
+
+    SmartcarException ex = SmartcarException.Factory(mockResponse);
+
+    Assert.assertEquals(ex.getMessage(), expectedMessage);
+  }
 }


### PR DESCRIPTION
Description:
When an error gets returned from oem_auth, it does not contain `message`, it has `error_description`. Since we were doing `Object.get("message").getAsString()` it was throwing a null exception error. 

Solution:
Check for `message` or `error_description` before converting to a string to avoid throwing a null exception error.

