### PR TITLE
Surface SC-Request-Id on batch requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ download links are also provided below.
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:2.4.0"
+compile "com.smartcar.sdk:java-sdk:2.4.1"
 ```
 
 ### Maven
@@ -19,14 +19,14 @@ compile "com.smartcar.sdk:java-sdk:2.4.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-2.4.0.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.0%2Fjava-sdk-2.4.0.jar)
-* [java-sdk-2.4.0-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.0%2Fjava-sdk-2.4.0-sources.jar)
-* [java-sdk-2.4.0-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.0%2Fjava-sdk-2.4.0-docs.jar)
+* [java-sdk-2.4.1.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.1%2Fjava-sdk-2.4.1.jar)
+* [java-sdk-2.4.1-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.1%2Fjava-sdk-2.4.1-sources.jar)
+* [java-sdk-2.4.1-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.4.1%2Fjava-sdk-2.4.1-docs.jar)
 
 
 ## Usage
@@ -129,5 +129,5 @@ start making requests to vehicles.
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-2.4.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-2.4.1-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk

--- a/docs/com/smartcar/sdk/data/BatchResponse.html
+++ b/docs/com/smartcar/sdk/data/BatchResponse.html
@@ -17,7 +17,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10,"i7":10,"i8":10,"i9":10,"i10":10,"i11":10};
 var tabs = {65535:["t0","All Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -180,42 +180,54 @@ extends <a href="../../../../com/smartcar/sdk/data/ApiData.html" title="class in
 </td>
 </tr>
 <tr id="i3" class="rowColor">
+<td class="colFirst"><code>java.lang.String</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#getRequestId--">getRequestId</a></span>()</code>
+<div class="block">Return the Smartcar request id from the response headers</div>
+</td>
+</tr>
+<tr id="i4" class="altColor">
 <td class="colFirst"><code><a href="../../../../com/smartcar/sdk/data/VehicleInfo.html" title="class in com.smartcar.sdk.data">VehicleInfo</a></code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#info--">info</a></span>()</code>
 <div class="block">Get response from the /info endpoint</div>
 </td>
 </tr>
-<tr id="i4" class="altColor">
+<tr id="i5" class="rowColor">
 <td class="colFirst"><code><a href="../../../../com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a>&lt;<a href="../../../../com/smartcar/sdk/data/VehicleLocation.html" title="class in com.smartcar.sdk.data">VehicleLocation</a>&gt;</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#location--">location</a></span>()</code>
 <div class="block">Get response from the /vin endpoint</div>
 </td>
 </tr>
-<tr id="i5" class="rowColor">
+<tr id="i6" class="altColor">
 <td class="colFirst"><code><a href="../../../../com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a>&lt;<a href="../../../../com/smartcar/sdk/data/VehicleOdometer.html" title="class in com.smartcar.sdk.data">VehicleOdometer</a>&gt;</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#odometer--">odometer</a></span>()</code>
 <div class="block">Get response from the /odometer endpoint</div>
 </td>
 </tr>
-<tr id="i6" class="altColor">
+<tr id="i7" class="rowColor">
 <td class="colFirst"><code><a href="../../../../com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a>&lt;<a href="../../../../com/smartcar/sdk/data/VehicleOil.html" title="class in com.smartcar.sdk.data">VehicleOil</a>&gt;</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#oil--">oil</a></span>()</code>
 <div class="block">Get response from the /engine/oil endpoint</div>
 </td>
 </tr>
-<tr id="i7" class="rowColor">
+<tr id="i8" class="altColor">
+<td class="colFirst"><code>void</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#setRequestId-java.lang.String-">setRequestId</a></span>(java.lang.String&nbsp;requestId)</code>
+<div class="block">Sets the Smartcar request id from the response headers</div>
+</td>
+</tr>
+<tr id="i9" class="rowColor">
 <td class="colFirst"><code><a href="../../../../com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a>&lt;<a href="../../../../com/smartcar/sdk/data/VehicleTirePressure.html" title="class in com.smartcar.sdk.data">VehicleTirePressure</a>&gt;</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#tirePressure--">tirePressure</a></span>()</code>
 <div class="block">Get response from the /tires/pressure endpoint</div>
 </td>
 </tr>
-<tr id="i8" class="altColor">
+<tr id="i10" class="altColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#toString--">toString</a></span>()</code>
 <div class="block">Returns the stored data string.</div>
 </td>
 </tr>
-<tr id="i9" class="rowColor">
+<tr id="i11" class="rowColor">
 <td class="colFirst"><code>java.lang.String</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/BatchResponse.html#vin--">vin</a></span>()</code>
 <div class="block">Get response from the /vin endpoint</div>
@@ -265,6 +277,34 @@ extends <a href="../../../../com/smartcar/sdk/data/ApiData.html" title="class in
 <!--   -->
 </a>
 <h3>Method Detail</h3>
+<a name="getRequestId--">
+<!--   -->
+</a>
+<ul class="blockList">
+<li class="blockList">
+<h4>getRequestId</h4>
+<pre>public&nbsp;java.lang.String&nbsp;getRequestId()</pre>
+<div class="block">Return the Smartcar request id from the response headers</div>
+<dl>
+<dt><span class="returnLabel">Returns:</span></dt>
+<dd>the request id</dd>
+</dl>
+</li>
+</ul>
+<a name="setRequestId-java.lang.String-">
+<!--   -->
+</a>
+<ul class="blockList">
+<li class="blockList">
+<h4>setRequestId</h4>
+<pre>public&nbsp;void&nbsp;setRequestId(java.lang.String&nbsp;requestId)</pre>
+<div class="block">Sets the Smartcar request id from the response headers</div>
+<dl>
+<dt><span class="paramLabel">Parameters:</span></dt>
+<dd><code>requestId</code> - the request id</dd>
+</dl>
+</li>
+</ul>
 <a name="battery--">
 <!--   -->
 </a>

--- a/docs/com/smartcar/sdk/data/SmartcarResponse.html
+++ b/docs/com/smartcar/sdk/data/SmartcarResponse.html
@@ -233,7 +233,7 @@ extends <a href="../../../../com/smartcar/sdk/data/ApiData.html" title="class in
 <tr id="i8" class="altColor">
 <td class="colFirst"><code>void</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/smartcar/sdk/data/SmartcarResponse.html#setRequestId-java.lang.String-">setRequestId</a></span>(java.lang.String&nbsp;requestId)</code>
-<div class="block">Stores the age of the response</div>
+<div class="block">Sets the Smartcar request id from the response headers</div>
 </td>
 </tr>
 <tr id="i9" class="rowColor">
@@ -461,7 +461,7 @@ extends <a href="../../../../com/smartcar/sdk/data/ApiData.html" title="class in
 <li class="blockList">
 <h4>setRequestId</h4>
 <pre>public&nbsp;void&nbsp;setRequestId(java.lang.String&nbsp;requestId)</pre>
-<div class="block">Stores the age of the response</div>
+<div class="block">Sets the Smartcar request id from the response headers</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>requestId</code> - the request id</dd>

--- a/docs/index-all.html
+++ b/docs/index-all.html
@@ -495,6 +495,10 @@
 <dd>
 <div class="block">Returns the currently stored refresh token.</div>
 </dd>
+<dt><span class="memberNameLink"><a href="com/smartcar/sdk/data/BatchResponse.html#getRequestId--">getRequestId()</a></span> - Method in class com.smartcar.sdk.data.<a href="com/smartcar/sdk/data/BatchResponse.html" title="class in com.smartcar.sdk.data">BatchResponse</a></dt>
+<dd>
+<div class="block">Return the Smartcar request id from the response headers</div>
+</dd>
 <dt><span class="memberNameLink"><a href="com/smartcar/sdk/data/SmartcarResponse.html#getRequestId--">getRequestId()</a></span> - Method in class com.smartcar.sdk.data.<a href="com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a></dt>
 <dd>
 <div class="block">Return the Smartcar request id from the response headers</div>
@@ -799,9 +803,13 @@
 <dd>
 <div class="block">Stores a new refresh token.</div>
 </dd>
+<dt><span class="memberNameLink"><a href="com/smartcar/sdk/data/BatchResponse.html#setRequestId-java.lang.String-">setRequestId(String)</a></span> - Method in class com.smartcar.sdk.data.<a href="com/smartcar/sdk/data/BatchResponse.html" title="class in com.smartcar.sdk.data">BatchResponse</a></dt>
+<dd>
+<div class="block">Sets the Smartcar request id from the response headers</div>
+</dd>
 <dt><span class="memberNameLink"><a href="com/smartcar/sdk/data/SmartcarResponse.html#setRequestId-java.lang.String-">setRequestId(String)</a></span> - Method in class com.smartcar.sdk.data.<a href="com/smartcar/sdk/data/SmartcarResponse.html" title="class in com.smartcar.sdk.data">SmartcarResponse</a></dt>
 <dd>
-<div class="block">Stores the age of the response</div>
+<div class="block">Sets the Smartcar request id from the response headers</div>
 </dd>
 <dt><span class="memberNameLink"><a href="com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setSingleSelect-boolean-">setSingleSelect(boolean)</a></span> - Method in class com.smartcar.sdk.<a href="com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></dt>
 <dd>&nbsp;</dd>

--- a/docs/serialized-form.html
+++ b/docs/serialized-form.html
@@ -186,6 +186,10 @@
 <li class="blockList">
 <h3>Serialized Fields</h3>
 <ul class="blockList">
+<li class="blockList">
+<h4>requestId</h4>
+<pre>java.lang.String requestId</pre>
+</li>
 <li class="blockListLast">
 <h4>responseData</h4>
 <pre>java.util.Map&lt;K,V&gt; responseData</pre>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=2.4.0
+libVersion=2.4.1
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/integration/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/integration/java/com/smartcar/sdk/VehicleTest.java
@@ -11,6 +11,7 @@ import com.smartcar.sdk.data.VehicleOdometer;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
+import java.util.Date;
 
 /**
  * Integration Test Suite: /vehicles/:id
@@ -67,6 +68,15 @@ public class VehicleTest extends IntegrationTest {
         this.vehicle.setUnitSystem(Vehicle.UnitSystem.IMPERIAL);
         SmartcarResponse response = this.vehicle.odometer();
         Assert.assertEquals(response.getUnitSystem(), "imperial");
+    }
+
+    /**
+     * Tests that the vehicle correctly handles age headers.
+     */
+    @Test(groups = "vehicle")
+    public void testAgeHeaders() throws SmartcarException {
+        SmartcarResponse response = this.vehicle.odometer();
+        Assert.assertTrue(response.getAge() instanceof Date);
     }
 
     /**
@@ -165,7 +175,6 @@ public class VehicleTest extends IntegrationTest {
 
     /**
      * Tests that the batch request method works.
-     *
      */
     @Test(groups = "vehicle")
     public void testBatch() throws SmartcarException, BatchResponseMissingException {
@@ -174,6 +183,22 @@ public class VehicleTest extends IntegrationTest {
 
         SmartcarResponse<VehicleOdometer> odo = response.odometer();
         SmartcarResponse<VehicleFuel> fuel = response.fuel();
+    }
+
+    /**
+     * Tests that the batch response headers are set properly.
+     */
+    @Test(groups = "vehicle")
+    public void testBatchResponseHeaders() throws SmartcarException, BatchResponseMissingException {
+        this.vehicle.setUnitSystem(Vehicle.UnitSystem.IMPERIAL);
+        String[] paths = {"/odometer"};
+        BatchResponse response = this.vehicle.batch(paths);
+        Assert.assertEquals(response.getRequestId().length(), 36);
+
+        SmartcarResponse<VehicleOdometer> odo = response.odometer();
+        Assert.assertEquals(odo.getUnitSystem(), "imperial");
+        Assert.assertEquals(odo.getRequestId().length(), 36);
+        Assert.assertTrue(odo.getAge() instanceof Date);
     }
 
     /**

--- a/src/main/java/com/smartcar/sdk/Vehicle.java
+++ b/src/main/java/com/smartcar/sdk/Vehicle.java
@@ -318,8 +318,10 @@ public class Vehicle extends ApiClient {
 
     this.gson.registerTypeAdapter(BatchResponse.class, new BatchDeserializer());
     RequestBody body = RequestBody.create(JSON, json.toString());
-    SmartcarResponse<BatchResponse> smartcarBatch = this.call("batch", "POST", body, BatchResponse.class);
-    return smartcarBatch.getData();
+    SmartcarResponse<BatchResponse> response = this.call("batch", "POST", body, BatchResponse.class);
+    BatchResponse batchResponse = response.getData();
+    batchResponse.setRequestId(response.getRequestId());
+    return batchResponse;
   }
 
 

--- a/src/main/java/com/smartcar/sdk/data/BatchResponse.java
+++ b/src/main/java/com/smartcar/sdk/data/BatchResponse.java
@@ -19,6 +19,7 @@ import org.joda.time.DateTime;
  * Smartcar BatchResponse Object
  */
 public class BatchResponse extends ApiData {
+    private String requestId;
     private Map<String, JsonObject> responseData = new HashMap<>();
     private static GsonBuilder gson = new GsonBuilder().setFieldNamingStrategy((field) -> toCamelCase(field.getName()));
 
@@ -69,24 +70,41 @@ public class BatchResponse extends ApiData {
     private <T extends ApiData> SmartcarResponse<T> createSmartcarResponse(JsonElement body, JsonElement header, Class<T> dataType) throws SmartcarException {
         T data = gson.create().fromJson(body, dataType);
 
-        String unitHeader;
+        SmartcarResponse<T> smartcarResponse = new SmartcarResponse<T>(data);
+        smartcarResponse.setRequestId(this.requestId);
+
         try {
-            unitHeader = header.getAsJsonObject().get("sc-unit-system").getAsString();
-        } catch (Exception e) {
-            unitHeader = null;
-        }
-        String ageHeader;
+            String unitSystem = header.getAsJsonObject().get("sc-unit-system").getAsString();
+            smartcarResponse.setUnitSystem(unitSystem);
+        } catch (Exception e) {}
+
         try {
-            ageHeader = header.getAsJsonObject().get("sc-data-age").getAsString();
-        } catch (Exception e) {
-            ageHeader = null;
-        }
-        if (ageHeader != null) {
-            DateTime date = DateTime.parse(ageHeader);
-            return new SmartcarResponse<T>(data, unitHeader, date.toDate());
-        } else {
-            return new SmartcarResponse<T>(data, unitHeader, null);
-        }
+            String ageHeader = header.getAsJsonObject().get("sc-data-age").getAsString();
+            if (ageHeader != null) {
+              DateTime date = DateTime.parse(ageHeader);
+              smartcarResponse.setAge(date.toDate());
+            }
+        } catch (Exception e) {}
+
+        return smartcarResponse;
+    }
+
+    /**
+     * Return the Smartcar request id from the response headers
+     *
+     * @return the request id
+     */
+    public String getRequestId() {
+      return this.requestId;
+    }
+
+    /**
+     * Sets the Smartcar request id from the response headers
+     *
+     * @param requestId the request id
+     */
+    public void setRequestId(String requestId) {
+      this.requestId = requestId;
     }
 
     /**

--- a/src/main/java/com/smartcar/sdk/data/SmartcarResponse.java
+++ b/src/main/java/com/smartcar/sdk/data/SmartcarResponse.java
@@ -121,7 +121,7 @@ public class SmartcarResponse<T extends ApiData> extends ApiData {
   }
 
   /**
-   * Stores the age of the response
+   * Sets the Smartcar request id from the response headers
    *
    * @param requestId the request id
    */

--- a/src/test/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/test/java/com/smartcar/sdk/VehicleTest.java
@@ -307,17 +307,23 @@ public class VehicleTest {
                         .build()
                 )
                 .build();
+        String expectedRequestId = "67127d3a-a08a-41f0-8211-f96da36b2d6e";
         RequestBody body = RequestBody.create(Vehicle.JSON, json.toString());
         JsonElement success = loadJsonResource("BatchResponseSuccess");
         BatchResponse expectedBatch = new BatchResponse(success.getAsJsonArray());
         SmartcarResponse<BatchResponse> res = new SmartcarResponse(expectedBatch);
+        res.setRequestId(expectedRequestId);
+
         PowerMockito.doReturn(res).when(this.subject, "call", eq("batch"), eq("POST"), refEq(body), refEq(BatchResponse.class));
 
         BatchResponse batch = this.subject.batch(new String[] {"/odometer"});
+        Assert.assertEquals(batch.getRequestId(), expectedRequestId);
 
         SmartcarResponse<VehicleOdometer> odo = batch.odometer();
         VehicleOdometer expectedOdo = new VehicleOdometer(32768);
         Assert.assertEquals(odo.getData().toString(), expectedOdo.toString());
+        Assert.assertEquals(odo.getUnitSystem(), "metric");
+        Assert.assertEquals(odo.getRequestId(), expectedRequestId);
     }
 
     @Test


### PR DESCRIPTION
The `getRequestId()` method is now available on both the `BatchResponse` class and the `SmartcarResponse` class.