### PR TITLE
 fix: update timeout so client has time to receive LB response

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ download links are also provided below.
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:2.6.0"
+compile "com.smartcar.sdk:java-sdk:2.6.1"
 ```
 
 ### Maven
@@ -19,14 +19,14 @@ compile "com.smartcar.sdk:java-sdk:2.6.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>2.6.0</version>
+  <version>2.6.1</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-2.6.0.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0.jar)
-* [java-sdk-2.6.0-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0-sources.jar)
-* [java-sdk-2.6.0-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0-docs.jar)
+* [java-sdk-2.6.1.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.1%2Fjava-sdk-2.6.1.jar)
+* [java-sdk-2.6.1-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.1%2Fjava-sdk-2.6.1-sources.jar)
+* [java-sdk-2.6.1-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.1%2Fjava-sdk-2.6.1-docs.jar)
 
 
 ## Usage
@@ -129,5 +129,5 @@ start making requests to vehicles.
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-2.6.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-2.6.1-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=2.6.0
+libVersion=2.6.1
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/main/java/com/smartcar/sdk/ApiClient.java
+++ b/src/main/java/com/smartcar/sdk/ApiClient.java
@@ -30,8 +30,7 @@ abstract class ApiClient {
   );
 
   private static OkHttpClient client = new OkHttpClient.Builder()
-    .readTimeout(300, TimeUnit.SECONDS)
-    .callTimeout(360, TimeUnit.SECONDS)
+    .readTimeout(310, TimeUnit.SECONDS)
     .build();
 
   private static String toCamelCase(String fieldName) {


### PR DESCRIPTION
- Increased the `readTimeout` to be 310 seconds so the client has time to receive the timeout response from the server.
- Removed `callTimeout` to allow to default to no timeout 

References:
- https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#callTimeout-java.time.Duration-
- https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.Builder.html#readTimeout-java.time.Duration-