### PR TITLE
feat: add country support for auth url + compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ download links are also provided below.
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:2.5.0"
+compile "com.smartcar.sdk:java-sdk:2.6.0"
 ```
 
 ### Maven
@@ -19,14 +19,14 @@ compile "com.smartcar.sdk:java-sdk:2.5.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>2.5.0</version>
+  <version>2.6.0</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-2.5.0.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.5.0%2Fjava-sdk-2.5.0.jar)
-* [java-sdk-2.5.0-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.5.0%2Fjava-sdk-2.5.0-sources.jar)
-* [java-sdk-2.5.0-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.5.0%2Fjava-sdk-2.5.0-docs.jar)
+* [java-sdk-2.6.0.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0.jar)
+* [java-sdk-2.6.0-sources.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0-sources.jar)
+* [java-sdk-2.6.0-docs.jar](https://bintray.com/smartcar/library/download_file?file_path=com%2Fsmartcar%2Fsdk%2Fjava-sdk%2F2.6.0%2Fjava-sdk-2.6.0-docs.jar)
 
 
 ## Usage
@@ -129,5 +129,5 @@ start making requests to vehicles.
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-2.5.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-2.6.0-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk

--- a/docs/com/smartcar/sdk/AuthClient.AuthUrlBuilder.html
+++ b/docs/com/smartcar/sdk/AuthClient.AuthUrlBuilder.html
@@ -17,7 +17,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10};
 var tabs = {65535:["t0","All Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -160,17 +160,21 @@ extends java.lang.Object</pre>
 </tr>
 <tr id="i2" class="altColor">
 <td class="colFirst"><code><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setMakeBypass-java.lang.String-">setMakeBypass</a></span>(java.lang.String&nbsp;make)</code>&nbsp;</td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setFlags-java.lang.String:A-">setFlags</a></span>(java.lang.String[]&nbsp;flags)</code>&nbsp;</td>
 </tr>
 <tr id="i3" class="rowColor">
 <td class="colFirst"><code><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setSingleSelect-boolean-">setSingleSelect</a></span>(boolean&nbsp;singleSelect)</code>&nbsp;</td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setMakeBypass-java.lang.String-">setMakeBypass</a></span>(java.lang.String&nbsp;make)</code>&nbsp;</td>
 </tr>
 <tr id="i4" class="altColor">
 <td class="colFirst"><code><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setSingleSelectVin-java.lang.String-">setSingleSelectVin</a></span>(java.lang.String&nbsp;vin)</code>&nbsp;</td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setSingleSelect-boolean-">setSingleSelect</a></span>(boolean&nbsp;singleSelect)</code>&nbsp;</td>
 </tr>
 <tr id="i5" class="rowColor">
+<td class="colFirst"><code><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setSingleSelectVin-java.lang.String-">setSingleSelectVin</a></span>(java.lang.String&nbsp;vin)</code>&nbsp;</td>
+</tr>
+<tr id="i6" class="altColor">
 <td class="colFirst"><code><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setState-java.lang.String-">setState</a></span>(java.lang.String&nbsp;state)</code>&nbsp;</td>
 </tr>
@@ -256,6 +260,15 @@ extends java.lang.Object</pre>
 <li class="blockList">
 <h4>setSingleSelectVin</h4>
 <pre>public&nbsp;<a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a>&nbsp;setSingleSelectVin(java.lang.String&nbsp;vin)</pre>
+</li>
+</ul>
+<a name="setFlags-java.lang.String:A-">
+<!--   -->
+</a>
+<ul class="blockList">
+<li class="blockList">
+<h4>setFlags</h4>
+<pre>public&nbsp;<a href="../../../com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a>&nbsp;setFlags(java.lang.String[]&nbsp;flags)</pre>
 </li>
 </ul>
 <a name="build--">

--- a/docs/com/smartcar/sdk/AuthClient.html
+++ b/docs/com/smartcar/sdk/AuthClient.html
@@ -17,7 +17,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":9,"i4":9,"i5":42,"i6":42,"i7":42,"i8":42,"i9":42,"i10":42,"i11":42,"i12":42,"i13":9,"i14":9,"i15":9,"i16":10,"i17":9};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":9,"i4":9,"i5":42,"i6":42,"i7":42,"i8":42,"i9":42,"i10":42,"i11":42,"i12":42,"i13":9,"i14":9,"i15":9,"i16":10,"i17":10,"i18":9};
 var tabs = {65535:["t0","All Methods"],1:["t1","Static Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"],32:["t6","Deprecated Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -390,6 +390,15 @@ extends java.lang.Object</pre>
 </td>
 </tr>
 <tr id="i17" class="rowColor">
+<td class="colFirst"><code>boolean</code></td>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.html#isCompatible-java.lang.String-java.lang.String:A-java.lang.String-">isCompatible</a></span>(java.lang.String&nbsp;vin,
+            java.lang.String[]&nbsp;scope,
+            java.lang.String&nbsp;country)</code>
+<div class="block">Determine if a vehicle is compatible with the Smartcar API and the provided permissions for
+ the specified country.</div>
+</td>
+</tr>
+<tr id="i18" class="altColor">
 <td class="colFirst"><code>static boolean</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../com/smartcar/sdk/AuthClient.html#isExpired-java.util.Date-">isExpired</a></span>(java.util.Date&nbsp;expiration)</code>
 <div class="block">Convenience method for determining if an auth token expiration has passed.</div>
@@ -891,6 +900,42 @@ public&nbsp;java.lang.String&nbsp;getAuthUrl()</pre>
 <dd><code>scope</code> - An array of permissions. The valid permissions are found in the API Reference.</dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>false if the vehicle is not compatible. true if the vehicle is likely compatible.</dd>
+<dt><span class="throwsLabel">Throws:</span></dt>
+<dd><code><a href="../../../com/smartcar/sdk/SmartcarException.html" title="class in com.smartcar.sdk">SmartcarException</a></code> - when the request is unsuccessful</dd>
+</dl>
+</li>
+</ul>
+<a name="isCompatible-java.lang.String-java.lang.String:A-java.lang.String-">
+<!--   -->
+</a>
+<ul class="blockList">
+<li class="blockList">
+<h4>isCompatible</h4>
+<pre>public&nbsp;boolean&nbsp;isCompatible(java.lang.String&nbsp;vin,
+                            java.lang.String[]&nbsp;scope,
+                            java.lang.String&nbsp;country)
+                     throws <a href="../../../com/smartcar/sdk/SmartcarException.html" title="class in com.smartcar.sdk">SmartcarException</a></pre>
+<div class="block">Determine if a vehicle is compatible with the Smartcar API and the provided permissions for
+ the specified country.
+ A compatible vehicle is a vehicle that:
+ <ol>
+ <li>
+ has the hardware required for internet connectivity,
+ </li>
+ <li>
+ belongs to the makes and models Smartcar supports, and
+ </li>
+ <li>
+ supports the permissions.
+ </li>
+ </ol></div>
+<dl>
+<dt><span class="paramLabel">Parameters:</span></dt>
+<dd><code>vin</code> - the VIN (Vehicle Identification Number) of the vehicle.</dd>
+<dd><code>scope</code> - An array of permissions. The valid permissions are found in the API Reference.</dd>
+<dd><code>country</code> - A country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)</dd>
+<dt><span class="returnLabel">Returns:</span></dt>
+<dd>false if the vehicle is not compatible in the specified country. true if the vehicle is likely compatible.</dd>
 <dt><span class="throwsLabel">Throws:</span></dt>
 <dd><code><a href="../../../com/smartcar/sdk/SmartcarException.html" title="class in com.smartcar.sdk">SmartcarException</a></code> - when the request is unsuccessful</dd>
 </dl>

--- a/docs/com/smartcar/sdk/AuthClient.html
+++ b/docs/com/smartcar/sdk/AuthClient.html
@@ -933,7 +933,7 @@ public&nbsp;java.lang.String&nbsp;getAuthUrl()</pre>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>vin</code> - the VIN (Vehicle Identification Number) of the vehicle.</dd>
 <dd><code>scope</code> - An array of permissions. The valid permissions are found in the API Reference.</dd>
-<dd><code>country</code> - A country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)</dd>
+<dd><code>country</code> - An optional country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)</dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>false if the vehicle is not compatible in the specified country. true if the vehicle is likely compatible.</dd>
 <dt><span class="throwsLabel">Throws:</span></dt>

--- a/docs/index-all.html
+++ b/docs/index-all.html
@@ -716,6 +716,8 @@
 <dd>
 <div class="block">Stores a new expiration timestamp for the current access token.</div>
 </dd>
+<dt><span class="memberNameLink"><a href="com/smartcar/sdk/AuthClient.AuthUrlBuilder.html#setFlags-java.lang.String:A-">setFlags(String[])</a></span> - Method in class com.smartcar.sdk.<a href="com/smartcar/sdk/AuthClient.AuthUrlBuilder.html" title="class in com.smartcar.sdk">AuthClient.AuthUrlBuilder</a></dt>
+<dd>&nbsp;</dd>
 <dt><span class="memberNameLink"><a href="com/smartcar/sdk/data/VehicleTirePressure.html#setFrontLeft-double-">setFrontLeft(double)</a></span> - Method in class com.smartcar.sdk.data.<a href="com/smartcar/sdk/data/VehicleTirePressure.html" title="class in com.smartcar.sdk.data">VehicleTirePressure</a></dt>
 <dd>
 <div class="block">Stores the front left tire pressure</div>

--- a/docs/index-all.html
+++ b/docs/index-all.html
@@ -584,6 +584,11 @@
 <dd>
 <div class="block">Determine if a vehicle is compatible with the Smartcar API and the provided permissions.</div>
 </dd>
+<dt><span class="memberNameLink"><a href="com/smartcar/sdk/AuthClient.html#isCompatible-java.lang.String-java.lang.String:A-java.lang.String-">isCompatible(String, String[], String)</a></span> - Method in class com.smartcar.sdk.<a href="com/smartcar/sdk/AuthClient.html" title="class in com.smartcar.sdk">AuthClient</a></dt>
+<dd>
+<div class="block">Determine if a vehicle is compatible with the Smartcar API and the provided permissions for
+ the specified country.</div>
+</dd>
 <dt><span class="memberNameLink"><a href="com/smartcar/sdk/AuthClient.html#isExpired-java.util.Date-">isExpired(Date)</a></span> - Static method in class com.smartcar.sdk.<a href="com/smartcar/sdk/AuthClient.html" title="class in com.smartcar.sdk">AuthClient</a></dt>
 <dd>
 <div class="block">Convenience method for determining if an auth token expiration has passed.</div>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=2.5.0
+libVersion=2.6.0
 libDescription=The Smartcar Java SDK
 libUrl=https://github.com/smartcar/java-sdk
 

--- a/src/integration/java/com/smartcar/sdk/AuthTest.java
+++ b/src/integration/java/com/smartcar/sdk/AuthTest.java
@@ -84,6 +84,26 @@ public class AuthTest extends IntegrationTest {
     }
 
     /**
+     * Test that compatibility is returned given scope and country
+     *
+     * @throws Exception if compatibility cannot be obtained
+     */
+    @Test
+    public void testIsCompatible() throws Exception {
+
+      String teslaVin = "5YJXCDE22HF068739";
+      String audiVin = "WAUAFAFL1GN014882";
+      String[] scope = new String[]{"read_location", "read_odometer"}; 
+      String country = "US"
+
+      boolean teslaComp = this.authClient.isCompatible(teslaVin, scope, country);
+      boolean audiComp = this.authClient.isCompatible(audiVin, scopem country);
+
+      assertTrue(teslaComp);
+      assertFalse(audiComp);
+    }
+
+    /**
      * Tests that a valid user ID can be obtained.
      *
      * @throws SmartcarException if the request fails

--- a/src/integration/java/com/smartcar/sdk/AuthTest.java
+++ b/src/integration/java/com/smartcar/sdk/AuthTest.java
@@ -89,15 +89,15 @@ public class AuthTest extends IntegrationTest {
      * @throws Exception if compatibility cannot be obtained
      */
     @Test
-    public void testIsCompatible() throws Exception {
+    public void testIsCompatibleWithCountry() throws Exception {
 
       String teslaVin = "5YJXCDE22HF068739";
       String audiVin = "WAUAFAFL1GN014882";
       String[] scope = new String[]{"read_location", "read_odometer"}; 
-      String country = "US"
+      String country = "US";
 
       boolean teslaComp = this.authClient.isCompatible(teslaVin, scope, country);
-      boolean audiComp = this.authClient.isCompatible(audiVin, scopem country);
+      boolean audiComp = this.authClient.isCompatible(audiVin, scope, country);
 
       assertTrue(teslaComp);
       assertFalse(audiComp);

--- a/src/integration/java/com/smartcar/sdk/IntegrationTest.java
+++ b/src/integration/java/com/smartcar/sdk/IntegrationTest.java
@@ -73,14 +73,14 @@ abstract class IntegrationTest {
      * @return a new set of auth credentials
      */
     Auth getAuth(String make) throws Exception {
-        AuthClient authClient = new AuthClient(
+        this.authClient = new AuthClient(
             this.authClientId,
             this.authClientSecret,
             this.authRedirectUri,
             this.authScope,
             this.authDevelopment
         );
-        String authUrl = authClient.new AuthUrlBuilder().build();
+        String authUrl = this.authClient.new AuthUrlBuilder().build();
         String authCode = this.getAuthCode(authUrl, this.authOemUsername, this.authOemPassword, make);
 
         Auth auth = authClient.exchangeCode(authCode);

--- a/src/integration/java/com/smartcar/sdk/IntegrationTest.java
+++ b/src/integration/java/com/smartcar/sdk/IntegrationTest.java
@@ -58,31 +58,21 @@ abstract class IntegrationTest {
      */
     Auth getAuth() throws Exception {
         if(IntegrationTest.auth == null) {
-            this.authClient = new AuthClient(
-                    this.authClientId,
-                    this.authClientSecret,
-                    this.authRedirectUri,
-                    this.authScope,
-                    this.authDevelopment
-            );
-            String authUrl = this.authClient.new AuthUrlBuilder().build();
-
-            String authCode = this.getAuthCode(authUrl, this.authOemUsername, this.authOemPassword, this.authMake);
-
-            IntegrationTest.auth = this.authClient.exchangeCode(authCode);
+            IntegrationTest.auth = this.getAuth(this.authMake);
         }
 
         return IntegrationTest.auth;
     }
 
     /**
-     * Allow for the creation of new Auth credentials with a specified make in addition (or instead) of the
-     * singleton approach of `getAuth`. This method allows for multiple auth credentials per test.
+     * Retrieves auth credentials for a specified make. This method does not
+     * maintain the auth singleton and returns a new auth credential every time
+     * it is invoked.
      *
      * @param make the make to be selected within the auth flow
-     * @return the current auth credentials
+     * @return a new set of auth credentials
      */
-    Auth getSpecificMakeAuth(String make) throws Exception {
+    Auth getAuth(String make) throws Exception {
         AuthClient authClient = new AuthClient(
             this.authClientId,
             this.authClientSecret,
@@ -106,7 +96,7 @@ abstract class IntegrationTest {
      * @return an authorized vehicle
      */
     Vehicle getVehicle(String make) throws Exception {
-        Auth auth = this.getSpecificMakeAuth(make);
+        Auth auth = this.getAuth(make);
         String accessToken = auth.getAccessToken();
 
         SmartcarResponse vehicleIdResponse = AuthClient.getVehicleIds(accessToken);

--- a/src/integration/java/com/smartcar/sdk/IntegrationTest.java
+++ b/src/integration/java/com/smartcar/sdk/IntegrationTest.java
@@ -1,6 +1,8 @@
 package com.smartcar.sdk;
 
 import com.smartcar.sdk.data.Auth;
+import com.smartcar.sdk.data.SmartcarResponse;
+import com.smartcar.sdk.data.VehicleIds;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -44,6 +46,7 @@ abstract class IntegrationTest {
             "read_charge",
             "control_charge"
     };
+    final String authMake = "CHEVROLET";
 
     WebDriver driver;
     WebDriverWait wait;
@@ -64,12 +67,55 @@ abstract class IntegrationTest {
             );
             String authUrl = this.authClient.new AuthUrlBuilder().build();
 
-            String authCode = this.getAuthCode(authUrl, this.authOemUsername, this.authOemPassword);
+            String authCode = this.getAuthCode(authUrl, this.authOemUsername, this.authOemPassword, this.authMake);
 
-            IntegrationTest.auth = authClient.exchangeCode(authCode);
+            IntegrationTest.auth = this.authClient.exchangeCode(authCode);
         }
 
         return IntegrationTest.auth;
+    }
+
+    /**
+     * Allow for the creation of new Auth credentials with a specified make in addition (or instead) of the
+     * singleton approach of `getAuth`. This method allows for multiple auth credentials per test.
+     *
+     * @param make the make to be selected within the auth flow
+     * @return the current auth credentials
+     */
+    Auth getSpecificMakeAuth(String make) throws Exception {
+        AuthClient authClient = new AuthClient(
+            this.authClientId,
+            this.authClientSecret,
+            this.authRedirectUri,
+            this.authScope,
+            this.authDevelopment
+        );
+        String authUrl = authClient.new AuthUrlBuilder().build();
+        String authCode = this.getAuthCode(authUrl, this.authOemUsername, this.authOemPassword, make);
+
+        Auth auth = authClient.exchangeCode(authCode);
+
+        return auth;
+    }
+
+    /**
+     * Obtain a single vehicle of the specified make with an authorization independent
+     * of the auth singleton created using `getAuth`
+     *
+     * @param make the make to be selected within the auth flow
+     * @return an authorized vehicle
+     */
+    Vehicle getVehicle(String make) throws Exception {
+        Auth auth = this.getSpecificMakeAuth(make);
+        String accessToken = auth.getAccessToken();
+
+        SmartcarResponse vehicleIdResponse = AuthClient.getVehicleIds(accessToken);
+        VehicleIds vehicleIdData = (VehicleIds) vehicleIdResponse.getData();
+        String[] vehicleIds = vehicleIdData.getVehicleIds();
+
+        Vehicle vehicle = new Vehicle(vehicleIds[0], accessToken);
+
+        return vehicle;
     }
 
     /**
@@ -82,7 +128,7 @@ abstract class IntegrationTest {
      * @return the resulting auth code
      * @throws Exception if the auth code could not be obtained
      */
-    private String getAuthCode(String connectAuthUrl, String oemUsername, String oemPassword) throws Exception {
+    private String getAuthCode(String connectAuthUrl, String oemUsername, String oemPassword, String make) throws Exception {
         this.startDriver();
 
         // 1 -- Initiate the OAuth 2.0 flow at https://connect.smartcar.com
@@ -92,7 +138,7 @@ abstract class IntegrationTest {
         this.driver.findElement(By.id("continue-button")).click();
 
         // 2 -- Find the Mock OEM button, and navigate to the Mock OEM login page.
-        this.driver.findElement(By.xpath("//button[@data-make='CHEVROLET' and @class='brand-selector-button']")).click();
+        this.driver.findElement(By.xpath("//button[@data-make='" + make +"' and @class='brand-selector-button']")).click();
 
         this.wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("input#username")));
 
@@ -106,7 +152,8 @@ abstract class IntegrationTest {
         this.wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(".page-content")));
 
         // Select Chevy Volt by unclicking all the boxes except the Volt
-        // This is needed because the Volt is the only one that has all the endpoints needed.
+        // Select Tesla Model S by unclicking all the boxes except the Model S
+        // This is needed because the Volt and Model S cover all the endpoints that are needed.
         List<WebElement> elements = this.driver.findElements(By.className("input-button-label"));
         for (WebElement el : elements) {
             WebElement vehicleText = el.findElement(By.className("input-button-label-text"));
@@ -115,7 +162,7 @@ abstract class IntegrationTest {
                 throw new Exception("input-button-label-text not found");
             } else if (checkbox == null) {
                 throw new Exception("input-button-custom not found");
-            } else if (!vehicleText.getText().contains("Volt")) {
+            } else if (!(vehicleText.getText().contains("Volt") || vehicleText.getText().contains("Model S"))) {
                 checkbox.click();
             }
         }

--- a/src/integration/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/integration/java/com/smartcar/sdk/VehicleTest.java
@@ -18,6 +18,7 @@ import java.util.Date;
  */
 public class VehicleTest extends IntegrationTest {
     private Vehicle vehicle;
+    private Vehicle eVehicle;
 
     /**
      * Authenticates with the Smartcar platform and initializes a vehicle.
@@ -26,14 +27,9 @@ public class VehicleTest extends IntegrationTest {
      */
     @BeforeSuite
     public void beforeSuite() throws Exception {
-        Auth auth = this.getAuth();
-        String accessToken = auth.getAccessToken();
-
-        SmartcarResponse vehicleIdResponse = AuthClient.getVehicleIds(accessToken);
-        VehicleIds vehicleIdData = (VehicleIds) vehicleIdResponse.getData();
-        String[] vehicleIds = vehicleIdData.getVehicleIds();
-
-        this.vehicle = new Vehicle(vehicleIds[0], this.getAuth().getAccessToken());
+        // we need both types of vehicles to get full coverage of all endpoints
+        this.vehicle = this.getVehicle("CHEVROLET");
+        this.eVehicle = this.getVehicle("TESLA");
     }
 
     /**
@@ -178,7 +174,7 @@ public class VehicleTest extends IntegrationTest {
      */
     @Test(groups = "vehicle")
     public void testActionStartCharge() throws SmartcarException {
-        this.vehicle.startCharge();
+        this.eVehicle.startCharge();
     }
 
     /**
@@ -186,7 +182,7 @@ public class VehicleTest extends IntegrationTest {
      */
     @Test(groups = "vehicle")
     public void testActionStopCharge() throws SmartcarException {
-        this.vehicle.stopCharge();
+        this.eVehicle.stopCharge();
     }
 
     /**

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -579,21 +579,7 @@ public class AuthClient extends ApiClient {
    * @throws SmartcarException when the request is unsuccessful
    */
   public boolean isCompatible(String vin, String[] scope) throws SmartcarException {
-    HttpUrl url = HttpUrl.parse(this.urlApi).newBuilder()
-        .addPathSegment("compatibility")
-        .addQueryParameter("vin", vin)
-        .addQueryParameter("scope", String.join(" ", scope))
-        .build();
-
-    Request request = new Request.Builder()
-        .url(url)
-        .header("Authorization", this.basicAuthorization)
-        .addHeader("User-Agent", AuthClient.USER_AGENT)
-        .get()
-        .build();
-
-    return AuthClient.execute(request, Compatibility.class)
-    	  .getData().getCompatible();
+    return isCompatible(vin, scope, null);
   }
 
     /**
@@ -620,12 +606,16 @@ public class AuthClient extends ApiClient {
    * @throws SmartcarException when the request is unsuccessful
    */
   public boolean isCompatible(String vin, String[] scope, String country) throws SmartcarException {
-    HttpUrl url = HttpUrl.parse(this.urlApi).newBuilder()
+    HttpUrl.Builder urlBase = HttpUrl.parse(this.urlApi).newBuilder()
         .addPathSegment("compatibility")
         .addQueryParameter("vin", vin)
-        .addQueryParameter("scope", String.join(" ", scope))
-        .addQueryParameter("country", country)
-        .build();
+        .addQueryParameter("scope", String.join(" ", scope));
+        
+    if (country != null) {
+      urlBase.addQueryParameter("country", country);
+    }
+
+    HttpUrl url = urlBase.build();
 
     Request request = new Request.Builder()
         .url(url)

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -579,7 +579,7 @@ public class AuthClient extends ApiClient {
    * @throws SmartcarException when the request is unsuccessful
    */
   public boolean isCompatible(String vin, String[] scope) throws SmartcarException {
-    return isCompatible(vin, scope, null);
+    return isCompatible(vin, scope, "US");
   }
 
     /**
@@ -606,16 +606,12 @@ public class AuthClient extends ApiClient {
    * @throws SmartcarException when the request is unsuccessful
    */
   public boolean isCompatible(String vin, String[] scope, String country) throws SmartcarException {
-    HttpUrl.Builder urlBase = HttpUrl.parse(this.urlApi).newBuilder()
+    HttpUrl url = HttpUrl.parse(this.urlApi).newBuilder()
         .addPathSegment("compatibility")
         .addQueryParameter("vin", vin)
-        .addQueryParameter("scope", String.join(" ", scope));
-        
-    if (country != null) {
-      urlBase.addQueryParameter("country", country);
-    }
-
-    HttpUrl url = urlBase.build();
+        .addQueryParameter("scope", String.join(" ", scope))
+        .addQueryParameter("country", country)
+        .build();
 
     Request request = new Request.Builder()
         .url(url)

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -364,6 +364,11 @@ public class AuthClient extends ApiClient {
       urlBuilder.addQueryParameter("single_select_vin", vin);
       return this;
     }
+ 
+    public AuthUrlBuilder setFlags(String[] flags) {
+      urlBuilder.addQueryParameter("flags", Utils.join(flags, " "));
+      return this;
+    }
 
     public String build() {
       return urlBuilder.build().toString();

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -599,7 +599,7 @@ public class AuthClient extends ApiClient {
    * </ol>
    * @param vin the VIN (Vehicle Identification Number) of the vehicle.
    * @param scope An array of permissions. The valid permissions are found in the API Reference.
-   * @param country A country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+   * @param country An optional country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
    *
    * @return false if the vehicle is not compatible in the specified country. true if the vehicle is likely compatible.
    *

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -595,5 +595,47 @@ public class AuthClient extends ApiClient {
     return AuthClient.execute(request, Compatibility.class)
     	  .getData().getCompatible();
   }
+
+    /**
+   * Determine if a vehicle is compatible with the Smartcar API and the provided permissions for
+   * the specified country.
+   * A compatible vehicle is a vehicle that:
+   * <ol>
+   * <li>
+   * has the hardware required for internet connectivity,
+   * </li>
+   * <li>
+   * belongs to the makes and models Smartcar supports, and
+   * </li>
+   * <li>
+   * supports the permissions.
+   * </li>
+   * </ol>
+   * @param vin the VIN (Vehicle Identification Number) of the vehicle.
+   * @param scope An array of permissions. The valid permissions are found in the API Reference.
+   * @param country A country code according to [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+   *
+   * @return false if the vehicle is not compatible in the specified country. true if the vehicle is likely compatible.
+   *
+   * @throws SmartcarException when the request is unsuccessful
+   */
+  public boolean isCompatible(String vin, String[] scope, String country) throws SmartcarException {
+    HttpUrl url = HttpUrl.parse(this.urlApi).newBuilder()
+        .addPathSegment("compatibility")
+        .addQueryParameter("vin", vin)
+        .addQueryParameter("scope", String.join(" ", scope))
+        .addQueryParameter("country", country)
+        .build();
+
+    Request request = new Request.Builder()
+        .url(url)
+        .header("Authorization", this.basicAuthorization)
+        .addHeader("User-Agent", AuthClient.USER_AGENT)
+        .get()
+        .build();
+
+    return AuthClient.execute(request, Compatibility.class)
+    	  .getData().getCompatible();
+  }
 }
 

--- a/src/test/java/com/smartcar/sdk/AuthClientTest.java
+++ b/src/test/java/com/smartcar/sdk/AuthClientTest.java
@@ -698,12 +698,14 @@ public class AuthClientTest extends PowerMockTestCase {
             true
     );
     String vin = "1234567890ABCDEFG";
+    String[] flags = {"country:DE", "flag:suboption"};
     String authUrl = client.authUrlBuilder()
             .setApprovalPrompt(true)
             .setState("state")
             .setSingleSelect(true)
             .setSingleSelectVin(vin)
             .setMakeBypass("TESLA")
+            .setFlags(flags)
             .build();
 
     String expectedAuthUrl = "https://connect.smartcar.com/oauth/authorize" +
@@ -716,7 +718,8 @@ public class AuthClientTest extends PowerMockTestCase {
             "&state=state" +
             "&single_select=true" +
             "&single_select_vin=" + vin +
-            "&make=TESLA";
+            "&make=TESLA" +
+            "&flags=country%3ADE%20flag%3Asuboption";
 
     assertEquals(authUrl, expectedAuthUrl);
   }

--- a/src/test/java/com/smartcar/sdk/CompatibilityRequest.java
+++ b/src/test/java/com/smartcar/sdk/CompatibilityRequest.java
@@ -7,7 +7,7 @@ import org.mockito.ArgumentMatcher;
 public class CompatibilityRequest extends ArgumentMatcher<Request> {
     @Override
     public boolean matches(Object arg) {
-        String url = "https://api.smartcar.com/v1.0/compatibility?vin=vin&scope=read_location%20read_odometer";
+        String url = "https://api.smartcar.com/v1.0/compatibility?vin=vin&scope=read_location%20read_odometer&country=US";
         Request request = (Request)arg;
         return url.equals(request.url().toString());
     }


### PR DESCRIPTION
Changes made:

1. Add new `setFlags` fn that allows users to set feature flags when generating their auth url
2. Overload `AuthClient.isCompatible` to also accept a `country` parameter for compatibility checks for specific countries

Also updated the tests to use Tesla as well bc start/stop charge was failing with the Chevy Volt :(