### PR TITLE
chore(ci): fix bug that lead to tags not being pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ jobs:
       deploy:
         - provider: script
           skip_cleanup: true
-          script:
-            - ./gradlew publish closeAndReleaseStagingRepository
-            - echo -e "machine github.com\n  login $GH_TOKEN" >> ~/.netrc && git push origin "v${SDK_VERSION}"
+          script: ./gradlew publish closeAndReleaseStagingRepository && echo -e "machine github.com\n  login $GH_TOKEN" >> ~/.netrc && git push origin "v${SDK_VERSION}"
           on:
             branch: master


### PR DESCRIPTION
If you need to run multiple commands, write a executable wrapper
script that runs them all. The argument to `script:` in the
script deployment provider needs to be a single command.

https://docs.travis-ci.com/user/deployment/script/