### PR TITLE
bug fix: testModeCompatibilityLevel query param camelCase -> snake_case

### DIFF
--- a/src/main/java/com/smartcar/sdk/Smartcar.java
+++ b/src/main/java/com/smartcar/sdk/Smartcar.java
@@ -152,7 +152,7 @@ public class Smartcar {
             urlBuilder.addQueryParameter("mode", "test");
         }
         if (compatibilityRequest.getTestModeCompatibilityLevel() != null) {
-            urlBuilder.addQueryParameter("testModeCompatibilityLevel", compatibilityRequest.getTestModeCompatibilityLevel());
+            urlBuilder.addQueryParameter("test_mode_compatibility_level", compatibilityRequest.getTestModeCompatibilityLevel());
         }
         HttpUrl url = urlBuilder.build();
 

--- a/src/test/java/com/smartcar/sdk/SmartcarTest.java
+++ b/src/test/java/com/smartcar/sdk/SmartcarTest.java
@@ -130,7 +130,7 @@ public class SmartcarTest extends PowerMockTestCase {
         Assert.assertTrue(comp.getCompatible());
         Assert.assertEquals(comp.getMeta().getRequestId(), this.sampleRequestId);
         RecordedRequest req = TestExecutionListener.mockWebServer.takeRequest();
-        Assert.assertEquals(req.getPath(), "/v1.0/compatibility?vin=1234&scope=read_odometer&country=GB&flags=foo%3Abar%20test%3Atrue&mode=test&testModeCompatibilityLevel=hello");
+        Assert.assertEquals(req.getPath(), "/v1.0/compatibility?vin=1234&scope=read_odometer&country=GB&flags=foo%3Abar%20test%3Atrue&mode=test&test_mode_compatibility_level=hello");
     }
 
     @Test


### PR DESCRIPTION
The Java SDK could not be used to test Compatibility API as was always getting error response 400 VALIDATION with
"detail":[{"field":"test_mode_compatibility_level","message":"Field must be one of: [compatible,phev,incompatible,fuel,dinosaur,bev]"}]
even when using one of those values.
The reason was that the SDK was incorrectly adding "testModeCompatibilityLevel"
as the query param instead of "test_mode_compatibility_level".
Fixed by this commit.