### PR TITLE
docs: update links to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smartcar Java SDK [![Build Status][ci-image]][ci-url] [![Code Coverage][coverage-image]][coverage-url] [![JavaDoc][javadoc-image]][javadoc-url] [![Maven Central](https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.smartcar.sdk%22%20AND%20a:%22java-sdk%22)
+# Smartcar Java SDK [![Build Status][ci-image]][ci-url] [![Code Coverage][coverage-image]][coverage-url] [![JavaDoc][javadoc-image]][javadoc-url] [![Maven Central][maven-image]][maven-url]
 
 ## Resources
  * [Smartcar Developer Dashboard][smartcar-developer]
@@ -23,11 +23,11 @@ compile "com.smartcar.sdk:java-sdk:3.9.0"
 ```
 
 ### Jar Direct Download
-* [java-sdk-3.9.0.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0.jar)
-* [java-sdk-3.9.0-sources.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0-sources.jar)
-* [java-sdk-3.9.0-javadoc.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0-javadoc.jar)
+* [java-sdk-3.9.0.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0.jar)
+* [java-sdk-3.9.0-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0-sources.jar)
+* [java-sdk-3.9.0-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.9.0/java-sdk-3.9.0-javadoc.jar)
 
-Signatures and other downloads available at [Maven Central](https://search.maven.org/artifact/com.smartcar.sdk/java-sdk/3.9.0/jar).
+Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/3.9.0).
 
 ## Usage
 
@@ -120,9 +120,9 @@ start making requests to vehicles.
     vehicle.unlock();
     ```
 
-## Supported Java Releases 
+## Supported Java Releases
 Smartcar aims to support the SDK on all LTS Java releases (and Java 8) until the "Extended Support" date as defined in the Oracle Java SE Support Roadmap
- 
+
 In accordance with the Semantic Versioning specification, the addition of support for new Java releases would result in a MINOR version bump and the removal of support for Java releases would result in a MAJOR version bump.
 
 [1]: https://tools.ietf.org/html/rfc6749#section-1.3.1
@@ -138,3 +138,5 @@ In accordance with the Semantic Versioning specification, the addition of suppor
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
 [javadoc-image]: https://img.shields.io/badge/javadoc-3.9.0-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk
+[maven-image]: https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central
+[maven-url]: https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk

--- a/README.mdt
+++ b/README.mdt
@@ -1,4 +1,4 @@
-# Smartcar Java SDK [![Build Status][ci-image]][ci-url] [![Code Coverage][coverage-image]][coverage-url] [![JavaDoc][javadoc-image]][javadoc-url] [![Maven Central](https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.smartcar.sdk%22%20AND%20a:%22java-sdk%22)
+# Smartcar Java SDK [![Build Status][ci-image]][ci-url] [![Code Coverage][coverage-image]][coverage-url] [![JavaDoc][javadoc-image]][javadoc-url] [![Maven Central][maven-image]][maven-url]
 
 ## Resources
  * [Smartcar Developer Dashboard][smartcar-developer]
@@ -23,11 +23,11 @@ compile "${libGroup}:${libName}:${libVersion}"
 ```
 
 ### Jar Direct Download
-* [${libName}-${libVersion}.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}.jar)
-* [${libName}-${libVersion}-sources.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}-sources.jar)
-* [${libName}-${libVersion}-javadoc.jar](https://search.maven.org/remotecontent?filepath=com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}-javadoc.jar)
+* [${libName}-${libVersion}.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}.jar)
+* [${libName}-${libVersion}-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}-sources.jar)
+* [${libName}-${libVersion}-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/${libVersion}/java-sdk-${libVersion}-javadoc.jar)
 
-Signatures and other downloads available at [Maven Central](https://search.maven.org/artifact/com.smartcar.sdk/java-sdk/${libVersion}/jar).
+Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/${libVersion}).
 
 ## Usage
 
@@ -120,9 +120,9 @@ start making requests to vehicles.
     vehicle.unlock();
     ```
 
-## Supported Java Releases 
+## Supported Java Releases
 Smartcar aims to support the SDK on all LTS Java releases (and Java 8) until the "Extended Support" date as defined in the Oracle Java SE Support Roadmap
- 
+
 In accordance with the Semantic Versioning specification, the addition of support for new Java releases would result in a MINOR version bump and the removal of support for Java releases would result in a MAJOR version bump.
 
 [1]: https://tools.ietf.org/html/rfc6749#section-1.3.1
@@ -138,3 +138,5 @@ In accordance with the Semantic Versioning specification, the addition of suppor
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
 [javadoc-image]: https://img.shields.io/badge/javadoc-${libVersion}-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk
+[maven-image]: https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central
+[maven-url]: https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk


### PR DESCRIPTION
The old links are now redirecting to these locations

Verified by clicking all old links and new links to make sure they are returning the same data

Asana: https://app.asana.com/0/1205492687081021/1205492826236061/f
