### PR TITLE
feat!: allow null fuel signal values

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The recommended method for obtaining the SDK is via Gradle or Maven through the 
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:3.11.0"
+compile "com.smartcar.sdk:java-sdk:4.0.0"
 ```
 
 ### Maven
@@ -18,16 +18,16 @@ compile "com.smartcar.sdk:java-sdk:3.11.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>3.11.0</version>
+  <version>4.0.0</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-3.11.0.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.11.0/java-sdk-3.11.0.jar)
-* [java-sdk-3.11.0-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.11.0/java-sdk-3.11.0-sources.jar)
-* [java-sdk-3.11.0-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/3.11.0/java-sdk-3.11.0-javadoc.jar)
+* [java-sdk-4.0.0.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.0.0/java-sdk-4.0.0.jar)
+* [java-sdk-4.0.0-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.0.0/java-sdk-4.0.0-sources.jar)
+* [java-sdk-4.0.0-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.0.0/java-sdk-4.0.0-javadoc.jar)
 
-Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/3.11.0).
+Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/4.0.0).
 
 ## Usage
 
@@ -136,7 +136,7 @@ In accordance with the Semantic Versioning specification, the addition of suppor
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-3.11.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-4.0.0-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk
 [maven-image]: https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central
 [maven-url]: https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=3.11.0
+libVersion=4.0.0
 libDescription=Smartcar Java SDK

--- a/src/main/java/com/smartcar/sdk/data/VehicleFuel.java
+++ b/src/main/java/com/smartcar/sdk/data/VehicleFuel.java
@@ -2,16 +2,16 @@ package com.smartcar.sdk.data;
 
 /** POJO for Smartcar /fuel endpoint */
 public class VehicleFuel extends ApiData {
-  private double range;
-  private double percentRemaining;
-  private double amountRemaining;
+  private Double range;
+  private Double percentRemaining;
+  private Double amountRemaining;
 
   /**
    * Returns the fuel range
    *
    * @return fuel range
    */
-  public double getRange() {
+  public Double getRange() {
     return this.range;
   }
 
@@ -20,7 +20,7 @@ public class VehicleFuel extends ApiData {
    *
    * @return fuel percent remaining
    */
-  public double getPercentRemaining() {
+  public Double getPercentRemaining() {
     return this.percentRemaining;
   }
 
@@ -29,7 +29,7 @@ public class VehicleFuel extends ApiData {
    *
    * @return fuel amount remaining
    */
-  public double getAmountRemaining() {
+  public Double getAmountRemaining() {
     return this.amountRemaining;
   }
 

--- a/src/test/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/test/java/com/smartcar/sdk/VehicleTest.java
@@ -169,9 +169,9 @@ public class VehicleTest {
 
     VehicleFuel fuel = this.subject.fuel();
 
-    Assert.assertEquals(fuel.getAmountRemaining(), 53.2);
-    Assert.assertEquals(fuel.getPercentRemaining(), 0.3);
-    Assert.assertEquals(fuel.getRange(), 40.5);
+    Assert.assertEquals(fuel.getAmountRemaining(), Double.valueOf(53.2));
+    Assert.assertEquals(fuel.getPercentRemaining(), Double.valueOf(0.3));
+    Assert.assertEquals(fuel.getRange(), Double.valueOf(40.5));
   }
 
   @Test


### PR DESCRIPTION
These changes allow the `range`, `percentRemaining`, and `amountRemaining` attributes to be set to null. This wasn't possible with primitive double types, as they always have a default value (0.0) if not explicitly set.


Asana: https://app.asana.com/0/1205850229375854/1205850230294701/f