### PR TITLE
feat(fuel)!: Fuel data types from primitives to objects

### DIFF
--- a/src/main/java/com/smartcar/sdk/data/VehicleFuel.java
+++ b/src/main/java/com/smartcar/sdk/data/VehicleFuel.java
@@ -2,16 +2,16 @@ package com.smartcar.sdk.data;
 
 /** POJO for Smartcar /fuel endpoint */
 public class VehicleFuel extends ApiData {
-  private double range;
-  private double percentRemaining;
-  private double amountRemaining;
+  private Double range;
+  private Double percentRemaining;
+  private Double amountRemaining;
 
   /**
    * Returns the fuel range
    *
    * @return fuel range
    */
-  public double getRange() {
+  public Double getRange() {
     return this.range;
   }
 
@@ -20,7 +20,7 @@ public class VehicleFuel extends ApiData {
    *
    * @return fuel percent remaining
    */
-  public double getPercentRemaining() {
+  public Double getPercentRemaining() {
     return this.percentRemaining;
   }
 
@@ -29,7 +29,7 @@ public class VehicleFuel extends ApiData {
    *
    * @return fuel amount remaining
    */
-  public double getAmountRemaining() {
+  public Double getAmountRemaining() {
     return this.amountRemaining;
   }
 

--- a/src/test/java/com/smartcar/sdk/VehicleTest.java
+++ b/src/test/java/com/smartcar/sdk/VehicleTest.java
@@ -169,9 +169,9 @@ public class VehicleTest {
 
     VehicleFuel fuel = this.subject.fuel();
 
-    Assert.assertEquals(fuel.getAmountRemaining(), 53.2);
-    Assert.assertEquals(fuel.getPercentRemaining(), 0.3);
-    Assert.assertEquals(fuel.getRange(), 40.5);
+    Assert.assertEquals(fuel.getAmountRemaining(), Double.valueOf(53.2));
+    Assert.assertEquals(fuel.getPercentRemaining(), Double.valueOf(0.3));
+    Assert.assertEquals(fuel.getRange(), Double.valueOf(40.5));
   }
 
   @Test


### PR DESCRIPTION
This is the change to update the data types is fuel endpoint to allow nulls when one or two of the fuel signals is empty.

This change might break the customers when one of the signals return null from the Smartcar API server. Customer need to be aware to map correctly the null cases.