### PR TITLE
feat: prevent all build dependencies from being packaged into a fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,9 +84,6 @@ jar {
         attributes('Implementation-Title': libName,
                 'Implementation-Version': libVersion)
     }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
 }
 
 /**


### PR DESCRIPTION
# Description

It isn't necessary to package all dependencies into a large "fat" jar. This change will remove all transitive dependencies from the final jar, and improve compatibility with other projects that might be operating with different versions of the same dependencies.

Fixes #107 and #139 