### PR TITLE
fix: Store static Gson instances rather than instantiating at request time

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The recommended method for obtaining the SDK is via Gradle or Maven through the 
 
 ### Gradle
 ```groovy
-compile "com.smartcar.sdk:java-sdk:4.7.0"
+compile "com.smartcar.sdk:java-sdk:4.7.1"
 ```
 
 ### Maven
@@ -18,16 +18,16 @@ compile "com.smartcar.sdk:java-sdk:4.7.0"
 <dependency>
   <groupId>com.smartcar.sdk</groupId>
   <artifactId>java-sdk</artifactId>
-  <version>4.7.0</version>
+  <version>4.7.1</version>
 </dependency>
 ```
 
 ### Jar Direct Download
-* [java-sdk-4.7.0.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.0/java-sdk-4.7.0.jar)
-* [java-sdk-4.7.0-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.0/java-sdk-4.7.0-sources.jar)
-* [java-sdk-4.7.0-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.0/java-sdk-4.7.0-javadoc.jar)
+* [java-sdk-4.7.1.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.1/java-sdk-4.7.1.jar)
+* [java-sdk-4.7.1-sources.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.1/java-sdk-4.7.1-sources.jar)
+* [java-sdk-4.7.1-javadoc.jar](https://repo1.maven.org/maven2/com/smartcar/sdk/java-sdk/4.7.1/java-sdk-4.7.1-javadoc.jar)
 
-Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/4.7.0).
+Signatures and other downloads available at [Maven Central](https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk/4.7.1).
 
 ## Usage
 
@@ -136,7 +136,7 @@ In accordance with the Semantic Versioning specification, the addition of suppor
 [ci-url]: https://travis-ci.com/smartcar/java-sdk
 [coverage-image]: https://codecov.io/gh/smartcar/java-sdk/branch/master/graph/badge.svg?token=nZAITx7w3X
 [coverage-url]: https://codecov.io/gh/smartcar/java-sdk
-[javadoc-image]: https://img.shields.io/badge/javadoc-4.7.0-brightgreen.svg
+[javadoc-image]: https://img.shields.io/badge/javadoc-4.7.1-brightgreen.svg
 [javadoc-url]: https://smartcar.github.io/java-sdk
 [maven-image]: https://img.shields.io/maven-central/v/com.smartcar.sdk/java-sdk.svg?label=Maven%20Central
 [maven-url]: https://central.sonatype.com/artifact/com.smartcar.sdk/java-sdk

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 libGroup=com.smartcar.sdk
 libName=java-sdk
-libVersion=4.7.0
+libVersion=4.7.1
 libDescription=Smartcar Java SDK

--- a/src/main/java/com/smartcar/sdk/ApiClient.java
+++ b/src/main/java/com/smartcar/sdk/ApiClient.java
@@ -7,8 +7,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
-import com.smartcar.sdk.data.ApiData;
-import com.smartcar.sdk.data.Meta;
+import com.smartcar.sdk.data.*;
+import com.smartcar.sdk.deserializer.AuthDeserializer;
+import com.smartcar.sdk.deserializer.BatchDeserializer;
+import com.smartcar.sdk.deserializer.VehicleResponseDeserializer;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -51,6 +53,9 @@ abstract class ApiClient {
 
   private static final Gson GSON_CAMEL_CASE = new GsonBuilder()
       .setFieldNamingStrategy(field -> Utils.toCamelCase(field.getName()))
+      .registerTypeAdapter(Auth.class, new AuthDeserializer())
+      .registerTypeAdapter(BatchResponse.class, new BatchDeserializer())
+      .registerTypeAdapter(VehicleResponse.class, new VehicleResponseDeserializer())
       .create();
 
   private static final Gson GSON_LOWER_CASE_WITH_UNDERSCORES = new GsonBuilder()

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -14,33 +14,6 @@ import java.util.stream.Stream;
 
 /** Smartcar OAuth 2.0 Authentication Client */
 public class AuthClient {
-  /** Custom deserializer for Auth data from the OAuth endpoint. */
-  private class AuthDeserializer implements JsonDeserializer<Auth> {
-    /**
-     * Deserializes the OAuth auth endpoint JSON into a new Auth object.
-     *
-     * @param json the Json data being deserialized
-     * @param typeOfT the type of the Object to deserialize to
-     * @param context the deserialization context
-     * @return the newly created Auth object
-     */
-    public Auth deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-      JsonObject jsonObject = json.getAsJsonObject();
-
-      // Get timestamp for expiration.
-      Calendar expiration = Calendar.getInstance();
-      expiration.add(Calendar.SECOND, jsonObject.get("expires_in").getAsInt());
-
-      Calendar refreshExpiration = Calendar.getInstance();
-      refreshExpiration.add(Calendar.DAY_OF_YEAR, 60);
-
-      return new Auth(
-          jsonObject.get("access_token").getAsString(),
-          jsonObject.get("refresh_token").getAsString(),
-          expiration.getTime(),
-          refreshExpiration.getTime());
-    }
-  }
 
   private final String clientId;
   private final String clientSecret;
@@ -120,8 +93,6 @@ public class AuthClient {
     this.clientSecret = builder.clientSecret;
     this.redirectUri = builder.redirectUri;
     this.mode = builder.mode;
-
-    ApiClient.gson.registerTypeAdapter(Auth.class, new AuthDeserializer());
   }
 
   /**

--- a/src/main/java/com/smartcar/sdk/AuthClient.java
+++ b/src/main/java/com/smartcar/sdk/AuthClient.java
@@ -1,13 +1,8 @@
 package com.smartcar.sdk;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.smartcar.sdk.data.Auth;
 import okhttp3.*;
 
-import java.lang.reflect.Type;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/com/smartcar/sdk/Vehicle.java
+++ b/src/main/java/com/smartcar/sdk/Vehicle.java
@@ -528,7 +528,6 @@ public class Vehicle {
 
     JsonObject json = Json.createObjectBuilder().add("requests", requests).build();
 
-    ApiClient.gson.registerTypeAdapter(BatchResponse.class, new BatchDeserializer());
     RequestBody body = RequestBody.create(ApiClient.JSON, json.toString());
     BatchResponse response = this.call("batch", "POST", body, BatchResponse.class);
     BatchResponse batchResponse = response;
@@ -578,8 +577,6 @@ public class Vehicle {
         vehicleRequest.getMethod(),
         vehicleRequest.getBody(),
         headers);
-
-    ApiClient.gson.registerTypeAdapter(VehicleResponse.class, new VehicleResponseDeserializer());
 
     VehicleResponse vehicleResponse = ApiClient.execute(request, VehicleResponse.class);
 

--- a/src/main/java/com/smartcar/sdk/deserializer/AuthDeserializer.java
+++ b/src/main/java/com/smartcar/sdk/deserializer/AuthDeserializer.java
@@ -1,0 +1,38 @@
+package com.smartcar.sdk.deserializer;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.smartcar.sdk.data.Auth;
+
+import java.lang.reflect.Type;
+import java.util.Calendar;
+
+/** Custom deserializer for Auth data from the OAuth endpoint. */
+public class AuthDeserializer implements JsonDeserializer<Auth> {
+    /**
+     * Deserializes the OAuth auth endpoint JSON into a new Auth object.
+     *
+     * @param json the Json data being deserialized
+     * @param typeOfT the type of the Object to deserialize to
+     * @param context the deserialization context
+     * @return the newly created Auth object
+     */
+    public Auth deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        JsonObject jsonObject = json.getAsJsonObject();
+
+        // Get timestamp for expiration.
+        Calendar expiration = Calendar.getInstance();
+        expiration.add(Calendar.SECOND, jsonObject.get("expires_in").getAsInt());
+
+        Calendar refreshExpiration = Calendar.getInstance();
+        refreshExpiration.add(Calendar.DAY_OF_YEAR, 60);
+
+        return new Auth(
+                jsonObject.get("access_token").getAsString(),
+                jsonObject.get("refresh_token").getAsString(),
+                expiration.getTime(),
+                refreshExpiration.getTime());
+    }
+}

--- a/src/main/java/com/smartcar/sdk/deserializer/BatchDeserializer.java
+++ b/src/main/java/com/smartcar/sdk/deserializer/BatchDeserializer.java
@@ -1,9 +1,11 @@
-package com.smartcar.sdk.data;
+package com.smartcar.sdk.deserializer;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.smartcar.sdk.data.BatchResponse;
+
 import java.lang.reflect.Type;
 
 /**

--- a/src/main/java/com/smartcar/sdk/deserializer/VehicleResponseDeserializer.java
+++ b/src/main/java/com/smartcar/sdk/deserializer/VehicleResponseDeserializer.java
@@ -1,9 +1,10 @@
-package com.smartcar.sdk.data;
+package com.smartcar.sdk.deserializer;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.smartcar.sdk.data.VehicleResponse;
 
 import java.lang.reflect.Type;
 

--- a/src/test/java/com/smartcar/sdk/ApiClientTest.java
+++ b/src/test/java/com/smartcar/sdk/ApiClientTest.java
@@ -1,6 +1,5 @@
 package com.smartcar.sdk;
 
-import com.smartcar.sdk.data.VehicleEngineOil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,13 +11,5 @@ public class ApiClientTest {
     // version has to be null because the package isn't built yet
     String regex = "^Smartcar/DEVELOPMENT \\((\\w+); (\\w+)\\) Java v(\\d+\\.\\d+\\.\\d_\\d+) .*";
     Assert.assertTrue(ApiClient.USER_AGENT.matches(regex));
-  }
-
-  @Test
-  public void testKeyParsing() {
-    String testData = "{\"lifeRemaining\":0.86}";
-
-    VehicleEngineOil data = ApiClient.gson.create().fromJson(testData, VehicleEngineOil.class);
-    Assert.assertTrue(data.getLifeRemaining() == 0.86);
   }
 }


### PR DESCRIPTION
Store two static Gson instances and use them for json deserialization. Currently these are instantiated on the fly for every request.

This required some refactoring to move the registration of the deserializers to `ApiClient`. 

Asana: https://app.asana.com/0/1209015700930832/1209128335756911