### PR TITLE
fix: Attach exception cause to built SmartcarException in ApiClient.execute

### DIFF
--- a/src/main/java/com/smartcar/sdk/ApiClient.java
+++ b/src/main/java/com/smartcar/sdk/ApiClient.java
@@ -164,6 +164,7 @@ abstract class ApiClient {
         bodyString = "Empty response body";
       }
       throw new SmartcarException.Builder()
+          .cause(ex)
           .statusCode(response.code())
           .description(bodyString)
           .requestId(response.headers().get("sc-request-id"))

--- a/src/main/java/com/smartcar/sdk/SmartcarException.java
+++ b/src/main/java/com/smartcar/sdk/SmartcarException.java
@@ -36,6 +36,7 @@ public class SmartcarException extends java.lang.Exception {
     private String requestId;
     private  int retryAfter;
     private String suggestedUserMessage;
+    private Throwable cause;
 
     public Builder() {
       this.statusCode = 0;
@@ -49,6 +50,7 @@ public class SmartcarException extends java.lang.Exception {
       this.requestId = "";
       this.retryAfter = 0;
       this.suggestedUserMessage = "";
+      this.cause = null;
     }
 
     public Builder statusCode(int statusCode) {
@@ -106,10 +108,16 @@ public class SmartcarException extends java.lang.Exception {
       return this;
     }
 
+    public Builder cause(Throwable throwable) {
+      this.cause = throwable;
+      return this;
+    }
+
     public SmartcarException build() { return new SmartcarException(this); }
   }
 
   private SmartcarException(Builder builder) {
+    super(builder.cause);
     this.statusCode = builder.statusCode;
     this.type = builder.type;
     this.code = builder.code;


### PR DESCRIPTION
This change is to get better visibility into exceptions thrown in `ApiClient.execute()`. Previously, the exception was caught and a new SmartcarException was built without a reference to the original exception. This means the stack trace for the SmartcarException would not contain the stack trace of the original exception. With this change, the original exception is set as the cause which will make it possible to determine the original exception.

Stack trace before:
```
com.smartcar.sdk.SmartcarException: SDK_ERROR:null - {"access_token":"xxxxxxxx","token_type":"Bearer","expires_in":7200,"refresh_token":"xxxxxxxx"}
	at com.smartcar.sdk.SmartcarException$Builder.build(SmartcarException.java:117)
	at com.smartcar.sdk.ApiClient.execute(ApiClient.java:174)
	at com.smartcar.sdk.AuthClient.getTokens(AuthClient.java:209)
	at com.smartcar.sdk.AuthClient.exchangeRefreshToken(AuthClient.java:270)
	at com.smartcar.sdk.AuthClient.exchangeRefreshToken(AuthClient.java:252)
	at com.smartcar.sdk.Main.test(Main.java:63)
	at com.smartcar.sdk.Main.main(Main.java:8)
```

Stack trace after:
```
com.smartcar.sdk.SmartcarException: SDK_ERROR:null - {"access_token":"xxxxxxxx","token_type":"Bearer","expires_in":7200,"refresh_token":"xxxxxxxx"}
	at com.smartcar.sdk.SmartcarException$Builder.build(SmartcarException.java:117)
	at com.smartcar.sdk.ApiClient.execute(ApiClient.java:174)
	at com.smartcar.sdk.AuthClient.getTokens(AuthClient.java:209)
	at com.smartcar.sdk.AuthClient.exchangeRefreshToken(AuthClient.java:270)
	at com.smartcar.sdk.AuthClient.exchangeRefreshToken(AuthClient.java:252)
	at com.smartcar.sdk.Main.test(Main.java:63)
	at com.smartcar.sdk.Main.main(Main.java:8)
Caused by: java.lang.RuntimeException: test exception
	at com.smartcar.sdk.ApiClient.execute(ApiClient.java:128)
	... 5 more
Caused by: java.lang.RuntimeException: test exception
```